### PR TITLE
refactor so that message receivers are distinct from events

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,14 +56,14 @@ module.exports = class Peer extends PingPeer {
     }, peer, peer.outport)
   }
 
-  on_local (msg) {
+  msg_local (msg) {
     if (!isAddr(msg)) // should never happen, but a peer could send anything.
     { return debug(1, 'local connect msg is invalid!', msg) }
     this.ping3(msg.id, msg)
   }
 
   // we received connect request, ping the target 3 itmes
-  on_connect (msg, _addr, _port, ts) {
+  msg_connect (msg, _addr, _port, ts) {
     if(!isConnect(msg)) return debug(1, 'invalid connect message:'+JSON.stringify(msg))
     assertTs(ts)
     if (!ts) throw new Error('ts must not be zero:' + ts)
@@ -177,10 +177,10 @@ module.exports = class Peer extends PingPeer {
 
   // stuff needed as an introducer
 
-  // rename: on_relay - relay a msg to a targeted (by id) peer.
+  // rename: msg_relay - relay a msg to a targeted (by id) peer.
   // will forward anything. used for creating local (private network) connections.
 
-  on_relay (msg, addr) {
+  msg_relay (msg, addr) {
     const target = this.peers[msg.target]
     if (!target) { return debug(1, 'cannot relay message to unkown peer:' + msg.target.substring(0, 8)) }
     this.send(msg.content, target, target.outport || this.localPort)
@@ -203,7 +203,7 @@ module.exports = class Peer extends PingPeer {
     this.send({ type: 'intro', id: this.id, nat: this.nat, target: id, swarm }, intro || this.peers[this.introducer1], this.localPort)
   }
 
-  on_intro (msg, addr) {
+  msg_intro (msg, addr) {
     // check nat types:
     // if both peers are easy, just tell each to connect to the other
     // if one is easy, one hard, birthday paradox connection

--- a/introducer.js
+++ b/introducer.js
@@ -46,7 +46,7 @@ module.exports = class Introducer extends Swarms {
     }
   }
 
-  on_connect () {
+  msg_connect () {
     //introducer does not receive connections
   }
 }

--- a/pings.js
+++ b/pings.js
@@ -137,26 +137,6 @@ module.exports = class PingPeer extends EventEmitter {
         this.emit('dead', peer)
       }
     }
-/*
-
-      if(!peer.pong && peer.send < ts - this.keepalive/2) {
-        debug(2, 'check peer:', peer.id.substring(0, 8))
-        this.ping(peer)
-      }
-      //if we have already received a pong, within the last 5 tries
-      else if (peer.pong && peer.pong.ts > ts - (this.keepalive*5)) {
-        debug(2, 'found peer:', peer.id.substring(0, 8), (ts - peer.pong.ts)/1000)
-        this.ping(peer)
-        this.emit('alive', peer) //XXX change to "found"
-      }
-      else { //if(!peer.pong) {
-        if (this.on_disconnect) this.on_disconnect(peer)
-         if(!this.peers[id].introducer) delete this.peers[id]
-        debug(1, "lost peer:", peer)
-        this.emit('dead', peer) //XXX change to "lost"
-      }
-    }
-    */
   }
 
   init (ts) {
@@ -300,7 +280,7 @@ module.exports = class PingPeer extends EventEmitter {
     }
   }
 
-  on_ping (msg, addr, _port, ts) {
+  msg_ping (msg, addr, _port, ts) {
     if(!isPing(msg)) return debug(1, 'ignored invalid ping:'+JSON.stringify(msg))
     assertTs(ts)
     if(this.restart == null) throw new Error('cannot have null restart time')
@@ -339,13 +319,13 @@ module.exports = class PingPeer extends EventEmitter {
     this.__notify_peer(msg.id)
   }
 
-  on_spin (msg, addr, _port, ts) {
+  msg_spin (msg, addr, _port, ts) {
     this.peers[msg.id].pong = this.peers[msg.id].pong || {ts, address: msg.address, port: msg.port}
     this.peers[msg.id].pong.spin = true
     checkNat(this) //sets nat to static and notifies if necessary
   }
 
-  on_pong (msg, addr, _port, ts) {
+  msg_pong (msg, addr, _port, ts) {
     if(!isPong(msg)) return debug(1, 'ignored invalid ping:'+JSON.stringify(msg))
     // XXX notify if this is a new peer message.
     // (sometimes we ping a peer, and their response is first contact)
@@ -366,8 +346,8 @@ module.exports = class PingPeer extends EventEmitter {
   }
 
   on_msg (msg, addr, port, ts) {
-    if (isString(msg.type) && isFunction(this['on_' + msg.type])) {
-      this['on_' + msg.type](msg, addr, port, ts)
+    if (isString(msg.type) && isFunction(this['msg_' + msg.type])) {
+      this['msg_' + msg.type](msg, addr, port, ts)
     }
     else 
       return false

--- a/swarm/append.js
+++ b/swarm/append.js
@@ -22,7 +22,7 @@ module.exports = class AppendSwarm extends Swarm {
     if (this.on_change) this.on_change(msg, this.data)
   }
 
-  on_chat (msg, peer) {
+  msg_chat (msg, peer) {
     const d = append(msg, this.data)
     if (d) {
       this.data = d

--- a/swarm/reliable.js
+++ b/swarm/reliable.js
@@ -18,7 +18,7 @@ module.exports = class ReliableSwarm extends Swarm {
   }
 
   // receive flooded message
-  on_update (msg, addr, port) {
+  msg_update (msg, addr, port) {
     let info = np.update(this.data, msg, msg.ts)
     this.data = info.state
     if (info.queued) {
@@ -47,7 +47,7 @@ module.exports = class ReliableSwarm extends Swarm {
     if (peer) { this.send(msg, peer) } else { this.swarmcast(msg, this.id) }
   }
 
-  on_head (msg, peer) {
+  msg_head (msg, peer) {
     // if we receive a head message, and we are not up to date with it, then request an update.
     if (!np.has(this.data, msg.head)) {
       this.request(msg.head, peer)
@@ -81,7 +81,7 @@ module.exports = class ReliableSwarm extends Swarm {
     )
   }
 
-  on_request (msg, addr, port) {
+  msg_request (msg, addr, port) {
     const a = np.missing(this.data, msg.have, msg.need)
     if (a.length) {
       for (let i = 0; i < a.length; i++) {

--- a/swarms.js
+++ b/swarms.js
@@ -86,7 +86,7 @@ module.exports = class Swarms extends Peer {
     debug(1, 'error:', msg)
   }
 
-  on_peer (peer) {
+  msg_peer (peer) {
     for(var swarm in this.swarms)
       if(this.swarms[swarm][peer.id]) {
         if(this.handlers[swarm] && this.handlers[swarm].on_peer)
@@ -184,7 +184,7 @@ module.exports = class Swarms extends Peer {
 
 
   // __set_peer (id, address, port, nat, outport, restart) {
-  on_join (msg, addr, port, ts) {
+  msg_join (msg, addr, port, ts) {
     if (port === undefined) throw new Error('undefined port')
 
     if (!isId(msg.swarm)) return debug(1, 'join, no swarm:', msg)
@@ -243,7 +243,7 @@ module.exports = class Swarms extends Peer {
         const swarm_id = msg.swarm
         const swarm = this.handlers[swarm_id]
         if (!swarm) return
-        const fn_name = 'on_' + msg.type
+        const fn_name = 'msg_' + msg.type
         if (typeof (swarm[fn_name]) === 'function') {
           swarm[fn_name](msg, peer, port, ts)
         }


### PR DESCRIPTION
when I started writing this, I wanted to see how it went just using something really basic and explicit for events.

so I had a convention that messages had a `type` field and if there was a method with that name it would call it when the message is received. But I also had events following that pattern... I knew which methods represented message receivers and which ones represented events... but the reader doesn't.

Also it's actually a security vuln for these to be shared, because an attacker could trigger any event by sending a message with the event name as the type.

This PR changes `on_` prefix to `msg_` , for messages. events are still the same.