### PR TITLE
Fix process.env when using Socket

### DIFF
--- a/util.js
+++ b/util.js
@@ -40,7 +40,7 @@ function isPeer (p) {
   )
 }
 
-const LEVEL = (globalThis.process ?? globalThis.__args)?.env?.DEBUG | 0
+const LEVEL = (globalThis.__args ?? globalThis.process)?.env?.DEBUG | 0
 const debug = LEVEL === 0
   ? () => {}
   : function debug (level, ...args) {

--- a/util.js
+++ b/util.js
@@ -40,7 +40,7 @@ function isPeer (p) {
   )
 }
 
-const LEVEL = +process.env.DEBUG | 0
+const LEVEL = (globalThis.process ?? globalThis.__args)?.env?.DEBUG | 0
 const debug = LEVEL === 0
   ? () => {}
   : function debug (level, ...args) {


### PR DESCRIPTION
This change is necessary because there is no more `process` global variable in Socket, it's a module in `io`'s `ipc-cleanup` branch